### PR TITLE
Session authentification & Ignore URLs via config file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
     "require": {
         "php": "~5.4",
         "symfony/console": "~2.6",
-        "umpirsky/centipede-crawler": "dev-master"
+        "umpirsky/centipede-crawler": "dev-master",
+        "symfony/yaml": "~2.3"
     },
     "require-dev": {
         "phpspec/phpspec": "~2.0"

--- a/src/Centipede/Console/Command/Run.php
+++ b/src/Centipede/Console/Command/Run.php
@@ -45,12 +45,17 @@ class Run extends Command
         $crawler = new Crawler(
             $input->getArgument('url'),
             $input->getArgument('depth'),
-            $input->getOption('ignore-url'),
             $authenticator
         );
 
-        $crawler->crawl(function ($url, Response $response) use ($output) {
+        $excludeUrls = $input->getOption('ignore-url');
+
+        $crawler->crawl(function ($url, Response $response) use ($excludeUrls, $output) {
             $tag = 'info';
+
+            if (in_array($url, $excludeUrls)) {
+                return;
+            }
 
             if (200 != $response->getStatus()) {
                 $this->exitCode = 1;

--- a/src/Centipede/Console/Command/Run.php
+++ b/src/Centipede/Console/Command/Run.php
@@ -64,7 +64,6 @@ class Run extends Command
                 $tag,
                 $url
             ));
-
         });
 
         return $this->exitCode;


### PR DESCRIPTION
``` shell
./bin/centipede run http://mywebsite.com --auth-method=session --session-name=SESSNAME --session-id=peigs2pqfjkdr4ms6k3epaamr2 --ignore-url=/app_dev.php/user/logout
```
- Ignore url (one or many)
- Auth user via authenticator, by default we provide SessionAuthenticator, --session-name is PHPSESSID by default. And you can add your own. Auth is totally optional.
- Fix depth, was not given to centipede-crawler before.

PR on centipede crawler is coming.
