### PR TITLE
Fix auto-loading with Composer "bin-dir" option

### DIFF
--- a/bin/centipede
+++ b/bin/centipede
@@ -10,7 +10,7 @@ function includeIfExists($file)
     return false;
 }
 
-if ((!$loader = includeIfExists(__DIR__.'/vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
+if ((!$loader = includeIfExists(__DIR__.'/../vendor/autoload.php')) && (!$loader = includeIfExists(__DIR__.'/../../../autoload.php'))) {
     die('You must set up the project dependencies, run the following commands:'.PHP_EOL.
         'curl -sS https://getcomposer.org/installer | php'.PHP_EOL.
         'php composer.phar install'.PHP_EOL);


### PR DESCRIPTION
When using Composer "bin-dir" to another folder than vendor/bin, the autoloading of centipede breaks.
The code used in this PR has been taken from SensioLabs' security-checker binaries, to ensure maximum correctness.
