### PR TITLE
Use a FutureResponse object in the run command

### DIFF
--- a/src/Centipede/Console/Command/Run.php
+++ b/src/Centipede/Console/Command/Run.php
@@ -2,11 +2,11 @@
 
 namespace Centipede\Console\Command;
 
+use GuzzleHttp\Message\FutureResponse;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\BrowserKit\Response;
 use Centipede\Crawler;
 
 class Run extends Command
@@ -27,9 +27,9 @@ class Run extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        (new Crawler($input->getArgument('url'), $input->getArgument('depth')))->crawl(function ($url, Response $response) use ($output) {
+        (new Crawler($input->getArgument('url'), $input->getArgument('depth')))->crawl(function ($url, FutureResponse $response) use ($output) {
             $tag = 'info';
-            if (200 != $response->getStatus()) {
+            if (200 != $response->getStatusCode()) {
                 $this->exitCode = 1;
                 $tag = 'error';
             }
@@ -37,7 +37,7 @@ class Run extends Command
             $output->writeln(sprintf(
                 '<%s>%d</%s> %s',
                 $tag,
-                $response->getStatus(),
+                $response->getStatusCode(),
                 $tag,
                 $url
             ));


### PR DESCRIPTION
When running `bin/centipede run http://mywebsite.com/`, I get the following error (using `dev-master` version of centipede, centipede-crawler and react/promise packages).

`PHP Catchable fatal error:  Argument 2 passed to Centipede\Console\Command\Run::Centipede\Console\Command\{closure}() must be an instance of Symfony\Component\BrowserKit\Response, instance of GuzzleHttp\Message\FutureResponse given, called in /pipeline/build/vendor/umpirsky/centipede-crawler/src/Centipede/Crawler.php on line 91 and defined in /pipeline/build/vendor/umpirsky/centipede/src/Centipede/Console/Command/Run.php on line 30`

This commit fixes the issue.