### PR TITLE
Allow symfony/console 3 to use

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/console": "~2.6",
+        "symfony/console": "~2.6|3",
         "umpirsky/centipede-crawler": "~0.1"
     },
     "require-dev": {


### PR DESCRIPTION
It's impossible to install it into projects using Symfony 3 without :(
